### PR TITLE
[AI] fix: data race in Source/Target Close vs callbacks

### DIFF
--- a/internal/templates/callback.go.tmpl
+++ b/internal/templates/callback.go.tmpl
@@ -15,12 +15,23 @@ func goLoggingHandler(domain *C.char, level C.int, message *C.char) {
 	log(C.GoString(domain), LogLevel(level), C.GoString(message))
 }
 
+// Source/Target callbacks acquire the matching Source/Target lock before
+// touching reader/writer/seeker fields, returning -1 (read/write error)
+// when a concurrent Close has already nil'd the field. Source.Close /
+// Target.Close hold the same lock through their s.reader = nil /
+// t.writer = nil writes, so libvips never observes torn state.
+
 //export goSourceRead
 func goSourceRead(
 	ptr unsafe.Pointer, buffer unsafe.Pointer, size C.longlong,
 ) C.longlong {
 	source, ok := pointer.Restore(ptr).(*Source)
 	if !ok {
+		return -1
+	}
+	source.lock.Lock()
+	defer source.lock.Unlock()
+	if source.reader == nil {
 		return -1
 	}
 	sh := &reflect.SliceHeader{
@@ -43,12 +54,18 @@ func goSourceSeek(
 	ptr unsafe.Pointer, offset C.longlong, whence int,
 ) C.longlong {
 	source, ok := pointer.Restore(ptr).(*Source)
-	if ok && source.seeker != nil {
-		switch whence {
-		case io.SeekStart, io.SeekCurrent, io.SeekEnd:
-			if n, err := source.seeker.Seek(int64(offset), whence); err == nil {
-				return C.longlong(n)
-			}
+	if !ok {
+		return -1
+	}
+	source.lock.Lock()
+	defer source.lock.Unlock()
+	if source.seeker == nil {
+		return -1
+	}
+	switch whence {
+	case io.SeekStart, io.SeekCurrent, io.SeekEnd:
+		if n, err := source.seeker.Seek(int64(offset), whence); err == nil {
+			return C.longlong(n)
 		}
 	}
 	return -1
@@ -60,6 +77,11 @@ func goTargetWrite(
 ) C.longlong {
 	target, ok := pointer.Restore(ptr).(*Target)
 	if !ok {
+		return -1
+	}
+	target.lock.Lock()
+	defer target.lock.Unlock()
+	if target.writer == nil {
 		return -1
 	}
 	sh := &reflect.SliceHeader{
@@ -80,12 +102,18 @@ func goTargetSeek(
 	ptr unsafe.Pointer, offset C.longlong, whence int,
 ) C.longlong {
 	target, ok := pointer.Restore(ptr).(*Target)
-	if ok && target.seeker != nil {
-		switch whence {
-		case io.SeekStart, io.SeekCurrent, io.SeekEnd:
-			if n, err := target.seeker.Seek(int64(offset), whence); err == nil {
-				return C.longlong(n)
-			}
+	if !ok {
+		return -1
+	}
+	target.lock.Lock()
+	defer target.lock.Unlock()
+	if target.seeker == nil {
+		return -1
+	}
+	switch whence {
+	case io.SeekStart, io.SeekCurrent, io.SeekEnd:
+		if n, err := target.seeker.Seek(int64(offset), whence); err == nil {
+			return C.longlong(n)
 		}
 	}
 	return -1

--- a/internal/templates/connection.go.tmpl
+++ b/internal/templates/connection.go.tmpl
@@ -37,24 +37,30 @@ func NewSource(reader io.ReadCloser) *Source {
 }
 
 // Close source
+//
+// Holds s.lock through the entire teardown (including the s.reader = nil
+// write) so it cannot race with goSourceRead, which also takes s.lock
+// before reading s.reader. C.clear_source -> g_clear_object only fires
+// GLib dispose/finalize handlers, never the registered "read" signal,
+// so calling it under the Go lock cannot deadlock against an in-flight
+// goSourceRead callback.
 func (s *Source) Close() {
 	if s == nil {
 		return
 	}
 	s.lock.Lock()
-	if s.ptr != nil {
-		C.clear_source(&s.src)
-		pointer.Unref(s.ptr)
-		s.ptr = nil
-		s.lock.Unlock()
-		if s.reader != nil {
-			_ = s.reader.Close()
-			s.reader = nil
-		}
-		log("vipsgen", LogLevelDebug, fmt.Sprintf("closing source %p", s))
-	} else {
-		s.lock.Unlock()
+	defer s.lock.Unlock()
+	if s.ptr == nil {
+		return
 	}
+	C.clear_source(&s.src)
+	pointer.Unref(s.ptr)
+	s.ptr = nil
+	if s.reader != nil {
+		_ = s.reader.Close()
+		s.reader = nil
+	}
+	log("vipsgen", LogLevelDebug, fmt.Sprintf("closing source %p", s))
 }
 
 // Target contains a libvips VipsTargetCustom and manages its lifecycle.
@@ -82,22 +88,25 @@ func NewTarget(writer io.WriteCloser) *Target {
 }
 
 // Close target
+//
+// Symmetric fix to Source.Close: holds t.lock through t.writer = nil so
+// it cannot race with goTargetWrite, which also takes t.lock before
+// reading t.writer.
 func (t *Target) Close() {
 	if t == nil {
 		return
 	}
 	t.lock.Lock()
-	if t.ptr != nil {
-		C.clear_target(&t.target)
-		pointer.Unref(t.ptr)
-		t.ptr = nil
-		t.lock.Unlock()
-		if t.writer != nil {
-			_ = t.writer.Close()
-			t.writer = nil
-		}
-		log("vipsgen", LogLevelDebug, fmt.Sprintf("closing target %p", t))
-	} else {
-		t.lock.Unlock()
+	defer t.lock.Unlock()
+	if t.ptr == nil {
+		return
 	}
+	C.clear_target(&t.target)
+	pointer.Unref(t.ptr)
+	t.ptr = nil
+	if t.writer != nil {
+		_ = t.writer.Close()
+		t.writer = nil
+	}
+	log("vipsgen", LogLevelDebug, fmt.Sprintf("closing target %p", t))
 }

--- a/vips/callback.go
+++ b/vips/callback.go
@@ -15,12 +15,23 @@ func goLoggingHandler(domain *C.char, level C.int, message *C.char) {
 	log(C.GoString(domain), LogLevel(level), C.GoString(message))
 }
 
+// Source/Target callbacks acquire the matching Source/Target lock before
+// touching reader/writer/seeker fields, returning -1 (read/write error)
+// when a concurrent Close has already nil'd the field. Source.Close /
+// Target.Close hold the same lock through their s.reader = nil /
+// t.writer = nil writes, so libvips never observes torn state.
+
 //export goSourceRead
 func goSourceRead(
 	ptr unsafe.Pointer, buffer unsafe.Pointer, size C.longlong,
 ) C.longlong {
 	source, ok := pointer.Restore(ptr).(*Source)
 	if !ok {
+		return -1
+	}
+	source.lock.Lock()
+	defer source.lock.Unlock()
+	if source.reader == nil {
 		return -1
 	}
 	sh := &reflect.SliceHeader{
@@ -43,12 +54,18 @@ func goSourceSeek(
 	ptr unsafe.Pointer, offset C.longlong, whence int,
 ) C.longlong {
 	source, ok := pointer.Restore(ptr).(*Source)
-	if ok && source.seeker != nil {
-		switch whence {
-		case io.SeekStart, io.SeekCurrent, io.SeekEnd:
-			if n, err := source.seeker.Seek(int64(offset), whence); err == nil {
-				return C.longlong(n)
-			}
+	if !ok {
+		return -1
+	}
+	source.lock.Lock()
+	defer source.lock.Unlock()
+	if source.seeker == nil {
+		return -1
+	}
+	switch whence {
+	case io.SeekStart, io.SeekCurrent, io.SeekEnd:
+		if n, err := source.seeker.Seek(int64(offset), whence); err == nil {
+			return C.longlong(n)
 		}
 	}
 	return -1
@@ -60,6 +77,11 @@ func goTargetWrite(
 ) C.longlong {
 	target, ok := pointer.Restore(ptr).(*Target)
 	if !ok {
+		return -1
+	}
+	target.lock.Lock()
+	defer target.lock.Unlock()
+	if target.writer == nil {
 		return -1
 	}
 	sh := &reflect.SliceHeader{
@@ -80,12 +102,18 @@ func goTargetSeek(
 	ptr unsafe.Pointer, offset C.longlong, whence int,
 ) C.longlong {
 	target, ok := pointer.Restore(ptr).(*Target)
-	if ok && target.seeker != nil {
-		switch whence {
-		case io.SeekStart, io.SeekCurrent, io.SeekEnd:
-			if n, err := target.seeker.Seek(int64(offset), whence); err == nil {
-				return C.longlong(n)
-			}
+	if !ok {
+		return -1
+	}
+	target.lock.Lock()
+	defer target.lock.Unlock()
+	if target.seeker == nil {
+		return -1
+	}
+	switch whence {
+	case io.SeekStart, io.SeekCurrent, io.SeekEnd:
+		if n, err := target.seeker.Seek(int64(offset), whence); err == nil {
+			return C.longlong(n)
 		}
 	}
 	return -1

--- a/vips/connection.go
+++ b/vips/connection.go
@@ -37,24 +37,30 @@ func NewSource(reader io.ReadCloser) *Source {
 }
 
 // Close source
+//
+// Holds s.lock through the entire teardown (including the s.reader = nil
+// write) so it cannot race with goSourceRead, which also takes s.lock
+// before reading s.reader. C.clear_source -> g_clear_object only fires
+// GLib dispose/finalize handlers, never the registered "read" signal,
+// so calling it under the Go lock cannot deadlock against an in-flight
+// goSourceRead callback.
 func (s *Source) Close() {
 	if s == nil {
 		return
 	}
 	s.lock.Lock()
-	if s.ptr != nil {
-		C.clear_source(&s.src)
-		pointer.Unref(s.ptr)
-		s.ptr = nil
-		s.lock.Unlock()
-		if s.reader != nil {
-			_ = s.reader.Close()
-			s.reader = nil
-		}
-		log("vipsgen", LogLevelDebug, fmt.Sprintf("closing source %p", s))
-	} else {
-		s.lock.Unlock()
+	defer s.lock.Unlock()
+	if s.ptr == nil {
+		return
 	}
+	C.clear_source(&s.src)
+	pointer.Unref(s.ptr)
+	s.ptr = nil
+	if s.reader != nil {
+		_ = s.reader.Close()
+		s.reader = nil
+	}
+	log("vipsgen", LogLevelDebug, fmt.Sprintf("closing source %p", s))
 }
 
 // Target contains a libvips VipsTargetCustom and manages its lifecycle.
@@ -82,22 +88,25 @@ func NewTarget(writer io.WriteCloser) *Target {
 }
 
 // Close target
+//
+// Symmetric fix to Source.Close: holds t.lock through t.writer = nil so
+// it cannot race with goTargetWrite, which also takes t.lock before
+// reading t.writer.
 func (t *Target) Close() {
 	if t == nil {
 		return
 	}
 	t.lock.Lock()
-	if t.ptr != nil {
-		C.clear_target(&t.target)
-		pointer.Unref(t.ptr)
-		t.ptr = nil
-		t.lock.Unlock()
-		if t.writer != nil {
-			_ = t.writer.Close()
-			t.writer = nil
-		}
-		log("vipsgen", LogLevelDebug, fmt.Sprintf("closing target %p", t))
-	} else {
-		t.lock.Unlock()
+	defer t.lock.Unlock()
+	if t.ptr == nil {
+		return
 	}
+	C.clear_target(&t.target)
+	pointer.Unref(t.ptr)
+	t.ptr = nil
+	if t.writer != nil {
+		_ = t.writer.Close()
+		t.writer = nil
+	}
+	log("vipsgen", LogLevelDebug, fmt.Sprintf("closing target %p", t))
 }

--- a/vips/race_helpers.go
+++ b/vips/race_helpers.go
@@ -1,0 +1,20 @@
+//go:build race
+
+// Helpers compiled only under -race. Kept in a non-_test.go file because
+// Go disallows cgo statements inside _test.go files when the package
+// already uses cgo (vips package builds with cgo via util.go etc.).
+
+package vips
+
+// #cgo pkg-config: vips
+// #include "util.h"
+import "C"
+
+// raceTestSetConcurrency sets libvips' worker thread count and returns the
+// previous value. Used by source_close_race_test.go to pin libvips to a
+// single worker thread for deterministic race-window reproduction.
+func raceTestSetConcurrency(n int) int {
+	prev := int(C.vips_concurrency_get())
+	C.vips_concurrency_set(C.int(n))
+	return prev
+}

--- a/vips/source_close_bench_test.go
+++ b/vips/source_close_bench_test.go
@@ -1,0 +1,102 @@
+package vips
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"testing"
+)
+
+// BenchmarkProcessJPEG_NoOps measures end-to-end cost of decoding a JPEG
+// through a custom Source and re-encoding through a custom Target — the
+// hot path for image-pipeline applications. Each iteration fires many
+// goSourceRead callbacks (decode) and goTargetWrite callbacks (encode),
+// so it captures the per-callback lock overhead introduced by the
+// Source/Target close-vs-callback race fix.
+func BenchmarkProcessJPEG_NoOps(b *testing.B) {
+	data := makeBenchJPEG(b, 800, 600)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := NewSource(io.NopCloser(bytes.NewReader(data)))
+		im, err := NewImageFromSource(src, nil)
+		if err != nil || im == nil {
+			b.Fatalf("NewImageFromSource: %v", err)
+		}
+		var out bytes.Buffer
+		tgt := NewTarget(benchNopWriteCloser{w: &out})
+		if err := im.JpegsaveTarget(tgt, nil); err != nil {
+			b.Fatalf("JpegsaveTarget: %v", err)
+		}
+		tgt.Close()
+		im.Close()
+		src.Close()
+	}
+}
+
+// BenchmarkProcessJPEG_Thumbnail measures shrink-on-load — the same path
+// as a typical thumbnail-generator service. Triggers many small reads via
+// the source callback during the shrink-on-load phase.
+func BenchmarkProcessJPEG_Thumbnail(b *testing.B) {
+	data := makeBenchJPEG(b, 1600, 1200)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := NewSource(io.NopCloser(bytes.NewReader(data)))
+		im, err := NewThumbnailSource(src, 200, &ThumbnailSourceOptions{
+			Height: 150,
+			Size:   SizeForce,
+		})
+		if err != nil || im == nil {
+			b.Fatalf("NewThumbnailSource: %v", err)
+		}
+		var out bytes.Buffer
+		tgt := NewTarget(benchNopWriteCloser{w: &out})
+		if err := im.JpegsaveTarget(tgt, nil); err != nil {
+			b.Fatalf("JpegsaveTarget: %v", err)
+		}
+		tgt.Close()
+		im.Close()
+		src.Close()
+	}
+}
+
+// BenchmarkSourceCloseSync isolates the Source.Close + NewSource cycle to
+// directly measure the cost of the per-callback sync.Mutex Lock/Unlock
+// added by the fix. No actual decode work — just the lifecycle overhead.
+func BenchmarkSourceCloseSync(b *testing.B) {
+	data := makeBenchJPEG(b, 100, 100)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := NewSource(io.NopCloser(bytes.NewReader(data)))
+		src.Close()
+	}
+}
+
+type benchNopWriteCloser struct{ w io.Writer }
+
+func (n benchNopWriteCloser) Write(p []byte) (int, error) { return n.w.Write(p) }
+func (n benchNopWriteCloser) Close() error                { return nil }
+
+func makeBenchJPEG(b *testing.B, w, h int) []byte {
+	b.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x * 7) % 256),
+				G: uint8((y * 13) % 256),
+				B: uint8(((x + y) * 3) % 256),
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80}); err != nil {
+		b.Fatalf("jpeg.Encode: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/vips/source_close_race_test.go
+++ b/vips/source_close_race_test.go
@@ -1,0 +1,165 @@
+//go:build race
+
+package vips
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"sync"
+	"testing"
+)
+
+// withSingleThreadedVips pins libvips to 1 worker thread for the duration of
+// the test, restoring the previous setting on exit. Single-threaded libvips
+// matches the moonglade fleet config where the race was first observed and
+// reliably surfaces it under -race; with auto-concurrency libvips finishes
+// callbacks fast enough that the race window almost always closes before
+// Source.Close runs in the calling goroutine. Implemented in
+// race_helpers.go so the cgo call is not in a _test.go file (Go disallows
+// cgo in test files when the surrounding package already uses cgo).
+func withSingleThreadedVips(t *testing.T) {
+	t.Helper()
+	prev := raceTestSetConcurrency(1)
+	t.Cleanup(func() { raceTestSetConcurrency(prev) })
+}
+
+// TestSource_CloseCallbackRace stresses (*Source).Close concurrent with the
+// goSourceRead callback fired by libvips while decoding through a custom
+// source. On the unpatched library the race detector reports:
+//
+//	WARNING: DATA RACE
+//	Write at 0x... by goroutine N:
+//	  vips.(*Source).Close()    connection.go:52   // s.reader = nil
+//	Previous read at 0x... by goroutine M:
+//	  vips.goSourceRead()       callback.go:32     // source.reader.Read
+//
+// Source.Close releases s.lock and then writes s.reader = nil outside the
+// lock; goSourceRead reads source.reader without holding any lock. After
+// libvips has released its synchronous reference, callback "extra"
+// goroutines (Go's cgo callback dispatchers) may still be unwinding when
+// Close runs — that is the race window.
+//
+// The trigger pattern is `Close source while a vips.Image keeps libvips'
+// reference alive`. shrink-on-load (NewThumbnailSource) reads enough bytes
+// to produce the thumbnail synchronously, but libvips may still hold the
+// source via the returned image until the image is destroyed; closing the
+// source first surfaces the race against the still-pending callback
+// goroutine. Build-tagged `race` so the load test is only compiled when
+// the race detector is the test verdict.
+func TestSource_CloseCallbackRace(t *testing.T) {
+	withSingleThreadedVips(t)
+	data := makeRaceTestJPEG(t, 800, 600)
+
+	workers := 16
+	const perWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range perWorker {
+				// Wrap the bytes reader in io.NopCloser so the Source falls
+				// through the non-seekable branch — same shape libvips ends up
+				// dispatching to a worker thread for.
+				src := NewSource(io.NopCloser(chainReader{r: bytes.NewReader(data)}))
+				// NewImageFromSource is lazy — the returned Image is an
+				// operation graph that pulls bytes from source on demand.
+				// JpegsaveTarget below forces the pull, firing goSourceRead
+				// callbacks on libvips worker goroutines. Closing the source
+				// while the image still holds the libvips reference is the
+				// race window.
+				im, err := NewImageFromSource(src, nil)
+				if err != nil || im == nil {
+					src.Close()
+					continue
+				}
+				var out bytes.Buffer
+				tgt := NewTarget(nopWriteCloser{w: &out})
+				// Close source first — image is still alive, libvips
+				// will still try to read through goSourceRead during
+				// JpegsaveTarget below.
+				src.Close()
+				_ = im.JpegsaveTarget(tgt, nil)
+				tgt.Close()
+				im.Close()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestTarget_CloseCallbackWriteRace mirrors the source test for Target.Close
+// vs goTargetWrite. Source is closed last so the source side of the
+// pipeline doesn't interfere; we close the Target while libvips may still
+// be flushing through goTargetWrite from JpegsaveTarget.
+func TestTarget_CloseCallbackWriteRace(t *testing.T) {
+	withSingleThreadedVips(t)
+	data := makeRaceTestJPEG(t, 800, 600)
+
+	workers := 16
+	const perWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range perWorker {
+				src := NewSource(io.NopCloser(chainReader{r: bytes.NewReader(data)}))
+				im, err := NewThumbnailSource(src, 100, nil)
+				if err != nil || im == nil {
+					src.Close()
+					continue
+				}
+				var out bytes.Buffer
+				tgt := NewTarget(nopWriteCloser{w: &out})
+				_ = im.JpegsaveTarget(tgt, nil)
+				// Close target BEFORE im.Close so libvips can still hold
+				// the target ref via the image during the unwind.
+				tgt.Close()
+				im.Close()
+				src.Close()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+type nopWriteCloser struct{ w io.Writer }
+
+func (n nopWriteCloser) Write(p []byte) (int, error) { return n.w.Write(p) }
+func (n nopWriteCloser) Close() error                { return nil }
+
+// chainReader wraps an io.Reader to mimic the wrapping-chain shape that
+// real-world callers produce (validating wrappers, decompression streams,
+// sniff buffers). The extra indirection slows Read just enough that the
+// cgo callback goroutine has not finished unwinding when Source.Close runs
+// in the calling goroutine — which is the race window. bytes.Reader.Read
+// is so fast the window almost never opens.
+type chainReader struct{ r io.Reader }
+
+func (c chainReader) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+func makeRaceTestJPEG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x * 7) % 256),
+				G: uint8((y * 13) % 256),
+				B: uint8(((x + y) * 3) % 256),
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80}); err != nil {
+		t.Fatalf("jpeg.Encode: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/vips816/callback.go
+++ b/vips816/callback.go
@@ -15,12 +15,23 @@ func goLoggingHandler(domain *C.char, level C.int, message *C.char) {
 	log(C.GoString(domain), LogLevel(level), C.GoString(message))
 }
 
+// Source/Target callbacks acquire the matching Source/Target lock before
+// touching reader/writer/seeker fields, returning -1 (read/write error)
+// when a concurrent Close has already nil'd the field. Source.Close /
+// Target.Close hold the same lock through their s.reader = nil /
+// t.writer = nil writes, so libvips never observes torn state.
+
 //export goSourceRead
 func goSourceRead(
 	ptr unsafe.Pointer, buffer unsafe.Pointer, size C.longlong,
 ) C.longlong {
 	source, ok := pointer.Restore(ptr).(*Source)
 	if !ok {
+		return -1
+	}
+	source.lock.Lock()
+	defer source.lock.Unlock()
+	if source.reader == nil {
 		return -1
 	}
 	sh := &reflect.SliceHeader{
@@ -43,12 +54,18 @@ func goSourceSeek(
 	ptr unsafe.Pointer, offset C.longlong, whence int,
 ) C.longlong {
 	source, ok := pointer.Restore(ptr).(*Source)
-	if ok && source.seeker != nil {
-		switch whence {
-		case io.SeekStart, io.SeekCurrent, io.SeekEnd:
-			if n, err := source.seeker.Seek(int64(offset), whence); err == nil {
-				return C.longlong(n)
-			}
+	if !ok {
+		return -1
+	}
+	source.lock.Lock()
+	defer source.lock.Unlock()
+	if source.seeker == nil {
+		return -1
+	}
+	switch whence {
+	case io.SeekStart, io.SeekCurrent, io.SeekEnd:
+		if n, err := source.seeker.Seek(int64(offset), whence); err == nil {
+			return C.longlong(n)
 		}
 	}
 	return -1
@@ -60,6 +77,11 @@ func goTargetWrite(
 ) C.longlong {
 	target, ok := pointer.Restore(ptr).(*Target)
 	if !ok {
+		return -1
+	}
+	target.lock.Lock()
+	defer target.lock.Unlock()
+	if target.writer == nil {
 		return -1
 	}
 	sh := &reflect.SliceHeader{
@@ -80,12 +102,18 @@ func goTargetSeek(
 	ptr unsafe.Pointer, offset C.longlong, whence int,
 ) C.longlong {
 	target, ok := pointer.Restore(ptr).(*Target)
-	if ok && target.seeker != nil {
-		switch whence {
-		case io.SeekStart, io.SeekCurrent, io.SeekEnd:
-			if n, err := target.seeker.Seek(int64(offset), whence); err == nil {
-				return C.longlong(n)
-			}
+	if !ok {
+		return -1
+	}
+	target.lock.Lock()
+	defer target.lock.Unlock()
+	if target.seeker == nil {
+		return -1
+	}
+	switch whence {
+	case io.SeekStart, io.SeekCurrent, io.SeekEnd:
+		if n, err := target.seeker.Seek(int64(offset), whence); err == nil {
+			return C.longlong(n)
 		}
 	}
 	return -1

--- a/vips816/connection.go
+++ b/vips816/connection.go
@@ -37,24 +37,30 @@ func NewSource(reader io.ReadCloser) *Source {
 }
 
 // Close source
+//
+// Holds s.lock through the entire teardown (including the s.reader = nil
+// write) so it cannot race with goSourceRead, which also takes s.lock
+// before reading s.reader. C.clear_source -> g_clear_object only fires
+// GLib dispose/finalize handlers, never the registered "read" signal,
+// so calling it under the Go lock cannot deadlock against an in-flight
+// goSourceRead callback.
 func (s *Source) Close() {
 	if s == nil {
 		return
 	}
 	s.lock.Lock()
-	if s.ptr != nil {
-		C.clear_source(&s.src)
-		pointer.Unref(s.ptr)
-		s.ptr = nil
-		s.lock.Unlock()
-		if s.reader != nil {
-			_ = s.reader.Close()
-			s.reader = nil
-		}
-		log("vipsgen", LogLevelDebug, fmt.Sprintf("closing source %p", s))
-	} else {
-		s.lock.Unlock()
+	defer s.lock.Unlock()
+	if s.ptr == nil {
+		return
 	}
+	C.clear_source(&s.src)
+	pointer.Unref(s.ptr)
+	s.ptr = nil
+	if s.reader != nil {
+		_ = s.reader.Close()
+		s.reader = nil
+	}
+	log("vipsgen", LogLevelDebug, fmt.Sprintf("closing source %p", s))
 }
 
 // Target contains a libvips VipsTargetCustom and manages its lifecycle.
@@ -82,22 +88,25 @@ func NewTarget(writer io.WriteCloser) *Target {
 }
 
 // Close target
+//
+// Symmetric fix to Source.Close: holds t.lock through t.writer = nil so
+// it cannot race with goTargetWrite, which also takes t.lock before
+// reading t.writer.
 func (t *Target) Close() {
 	if t == nil {
 		return
 	}
 	t.lock.Lock()
-	if t.ptr != nil {
-		C.clear_target(&t.target)
-		pointer.Unref(t.ptr)
-		t.ptr = nil
-		t.lock.Unlock()
-		if t.writer != nil {
-			_ = t.writer.Close()
-			t.writer = nil
-		}
-		log("vipsgen", LogLevelDebug, fmt.Sprintf("closing target %p", t))
-	} else {
-		t.lock.Unlock()
+	defer t.lock.Unlock()
+	if t.ptr == nil {
+		return
 	}
+	C.clear_target(&t.target)
+	pointer.Unref(t.ptr)
+	t.ptr = nil
+	if t.writer != nil {
+		_ = t.writer.Close()
+		t.writer = nil
+	}
+	log("vipsgen", LogLevelDebug, fmt.Sprintf("closing target %p", t))
 }

--- a/vips816/race_helpers.go
+++ b/vips816/race_helpers.go
@@ -1,0 +1,20 @@
+//go:build race
+
+// Helpers compiled only under -race. Kept in a non-_test.go file because
+// Go disallows cgo statements inside _test.go files when the package
+// already uses cgo (vips package builds with cgo via util.go etc.).
+
+package vips
+
+// #cgo pkg-config: vips
+// #include "util.h"
+import "C"
+
+// raceTestSetConcurrency sets libvips' worker thread count and returns the
+// previous value. Used by source_close_race_test.go to pin libvips to a
+// single worker thread for deterministic race-window reproduction.
+func raceTestSetConcurrency(n int) int {
+	prev := int(C.vips_concurrency_get())
+	C.vips_concurrency_set(C.int(n))
+	return prev
+}

--- a/vips816/source_close_bench_test.go
+++ b/vips816/source_close_bench_test.go
@@ -1,0 +1,102 @@
+package vips
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"testing"
+)
+
+// BenchmarkProcessJPEG_NoOps measures end-to-end cost of decoding a JPEG
+// through a custom Source and re-encoding through a custom Target — the
+// hot path for image-pipeline applications. Each iteration fires many
+// goSourceRead callbacks (decode) and goTargetWrite callbacks (encode),
+// so it captures the per-callback lock overhead introduced by the
+// Source/Target close-vs-callback race fix.
+func BenchmarkProcessJPEG_NoOps(b *testing.B) {
+	data := makeBenchJPEG(b, 800, 600)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := NewSource(io.NopCloser(bytes.NewReader(data)))
+		im, err := NewImageFromSource(src, nil)
+		if err != nil || im == nil {
+			b.Fatalf("NewImageFromSource: %v", err)
+		}
+		var out bytes.Buffer
+		tgt := NewTarget(benchNopWriteCloser{w: &out})
+		if err := im.JpegsaveTarget(tgt, nil); err != nil {
+			b.Fatalf("JpegsaveTarget: %v", err)
+		}
+		tgt.Close()
+		im.Close()
+		src.Close()
+	}
+}
+
+// BenchmarkProcessJPEG_Thumbnail measures shrink-on-load — the same path
+// as a typical thumbnail-generator service. Triggers many small reads via
+// the source callback during the shrink-on-load phase.
+func BenchmarkProcessJPEG_Thumbnail(b *testing.B) {
+	data := makeBenchJPEG(b, 1600, 1200)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := NewSource(io.NopCloser(bytes.NewReader(data)))
+		im, err := NewThumbnailSource(src, 200, &ThumbnailSourceOptions{
+			Height: 150,
+			Size:   SizeForce,
+		})
+		if err != nil || im == nil {
+			b.Fatalf("NewThumbnailSource: %v", err)
+		}
+		var out bytes.Buffer
+		tgt := NewTarget(benchNopWriteCloser{w: &out})
+		if err := im.JpegsaveTarget(tgt, nil); err != nil {
+			b.Fatalf("JpegsaveTarget: %v", err)
+		}
+		tgt.Close()
+		im.Close()
+		src.Close()
+	}
+}
+
+// BenchmarkSourceCloseSync isolates the Source.Close + NewSource cycle to
+// directly measure the cost of the per-callback sync.Mutex Lock/Unlock
+// added by the fix. No actual decode work — just the lifecycle overhead.
+func BenchmarkSourceCloseSync(b *testing.B) {
+	data := makeBenchJPEG(b, 100, 100)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := NewSource(io.NopCloser(bytes.NewReader(data)))
+		src.Close()
+	}
+}
+
+type benchNopWriteCloser struct{ w io.Writer }
+
+func (n benchNopWriteCloser) Write(p []byte) (int, error) { return n.w.Write(p) }
+func (n benchNopWriteCloser) Close() error                { return nil }
+
+func makeBenchJPEG(b *testing.B, w, h int) []byte {
+	b.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x * 7) % 256),
+				G: uint8((y * 13) % 256),
+				B: uint8(((x + y) * 3) % 256),
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80}); err != nil {
+		b.Fatalf("jpeg.Encode: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/vips816/source_close_race_test.go
+++ b/vips816/source_close_race_test.go
@@ -1,0 +1,165 @@
+//go:build race
+
+package vips
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"sync"
+	"testing"
+)
+
+// withSingleThreadedVips pins libvips to 1 worker thread for the duration of
+// the test, restoring the previous setting on exit. Single-threaded libvips
+// matches the moonglade fleet config where the race was first observed and
+// reliably surfaces it under -race; with auto-concurrency libvips finishes
+// callbacks fast enough that the race window almost always closes before
+// Source.Close runs in the calling goroutine. Implemented in
+// race_helpers.go so the cgo call is not in a _test.go file (Go disallows
+// cgo in test files when the surrounding package already uses cgo).
+func withSingleThreadedVips(t *testing.T) {
+	t.Helper()
+	prev := raceTestSetConcurrency(1)
+	t.Cleanup(func() { raceTestSetConcurrency(prev) })
+}
+
+// TestSource_CloseCallbackRace stresses (*Source).Close concurrent with the
+// goSourceRead callback fired by libvips while decoding through a custom
+// source. On the unpatched library the race detector reports:
+//
+//	WARNING: DATA RACE
+//	Write at 0x... by goroutine N:
+//	  vips.(*Source).Close()    connection.go:52   // s.reader = nil
+//	Previous read at 0x... by goroutine M:
+//	  vips.goSourceRead()       callback.go:32     // source.reader.Read
+//
+// Source.Close releases s.lock and then writes s.reader = nil outside the
+// lock; goSourceRead reads source.reader without holding any lock. After
+// libvips has released its synchronous reference, callback "extra"
+// goroutines (Go's cgo callback dispatchers) may still be unwinding when
+// Close runs — that is the race window.
+//
+// The trigger pattern is `Close source while a vips.Image keeps libvips'
+// reference alive`. shrink-on-load (NewThumbnailSource) reads enough bytes
+// to produce the thumbnail synchronously, but libvips may still hold the
+// source via the returned image until the image is destroyed; closing the
+// source first surfaces the race against the still-pending callback
+// goroutine. Build-tagged `race` so the load test is only compiled when
+// the race detector is the test verdict.
+func TestSource_CloseCallbackRace(t *testing.T) {
+	withSingleThreadedVips(t)
+	data := makeRaceTestJPEG(t, 800, 600)
+
+	workers := 16
+	const perWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range perWorker {
+				// Wrap the bytes reader in io.NopCloser so the Source falls
+				// through the non-seekable branch — same shape libvips ends up
+				// dispatching to a worker thread for.
+				src := NewSource(io.NopCloser(chainReader{r: bytes.NewReader(data)}))
+				// NewImageFromSource is lazy — the returned Image is an
+				// operation graph that pulls bytes from source on demand.
+				// JpegsaveTarget below forces the pull, firing goSourceRead
+				// callbacks on libvips worker goroutines. Closing the source
+				// while the image still holds the libvips reference is the
+				// race window.
+				im, err := NewImageFromSource(src, nil)
+				if err != nil || im == nil {
+					src.Close()
+					continue
+				}
+				var out bytes.Buffer
+				tgt := NewTarget(nopWriteCloser{w: &out})
+				// Close source first — image is still alive, libvips
+				// will still try to read through goSourceRead during
+				// JpegsaveTarget below.
+				src.Close()
+				_ = im.JpegsaveTarget(tgt, nil)
+				tgt.Close()
+				im.Close()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestTarget_CloseCallbackWriteRace mirrors the source test for Target.Close
+// vs goTargetWrite. Source is closed last so the source side of the
+// pipeline doesn't interfere; we close the Target while libvips may still
+// be flushing through goTargetWrite from JpegsaveTarget.
+func TestTarget_CloseCallbackWriteRace(t *testing.T) {
+	withSingleThreadedVips(t)
+	data := makeRaceTestJPEG(t, 800, 600)
+
+	workers := 16
+	const perWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range perWorker {
+				src := NewSource(io.NopCloser(chainReader{r: bytes.NewReader(data)}))
+				im, err := NewThumbnailSource(src, 100, nil)
+				if err != nil || im == nil {
+					src.Close()
+					continue
+				}
+				var out bytes.Buffer
+				tgt := NewTarget(nopWriteCloser{w: &out})
+				_ = im.JpegsaveTarget(tgt, nil)
+				// Close target BEFORE im.Close so libvips can still hold
+				// the target ref via the image during the unwind.
+				tgt.Close()
+				im.Close()
+				src.Close()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+type nopWriteCloser struct{ w io.Writer }
+
+func (n nopWriteCloser) Write(p []byte) (int, error) { return n.w.Write(p) }
+func (n nopWriteCloser) Close() error                { return nil }
+
+// chainReader wraps an io.Reader to mimic the wrapping-chain shape that
+// real-world callers produce (validating wrappers, decompression streams,
+// sniff buffers). The extra indirection slows Read just enough that the
+// cgo callback goroutine has not finished unwinding when Source.Close runs
+// in the calling goroutine — which is the race window. bytes.Reader.Read
+// is so fast the window almost never opens.
+type chainReader struct{ r io.Reader }
+
+func (c chainReader) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+func makeRaceTestJPEG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x * 7) % 256),
+				G: uint8((y * 13) % 256),
+				B: uint8(((x + y) * 3) % 256),
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80}); err != nil {
+		t.Fatalf("jpeg.Encode: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/vips817/callback.go
+++ b/vips817/callback.go
@@ -15,12 +15,23 @@ func goLoggingHandler(domain *C.char, level C.int, message *C.char) {
 	log(C.GoString(domain), LogLevel(level), C.GoString(message))
 }
 
+// Source/Target callbacks acquire the matching Source/Target lock before
+// touching reader/writer/seeker fields, returning -1 (read/write error)
+// when a concurrent Close has already nil'd the field. Source.Close /
+// Target.Close hold the same lock through their s.reader = nil /
+// t.writer = nil writes, so libvips never observes torn state.
+
 //export goSourceRead
 func goSourceRead(
 	ptr unsafe.Pointer, buffer unsafe.Pointer, size C.longlong,
 ) C.longlong {
 	source, ok := pointer.Restore(ptr).(*Source)
 	if !ok {
+		return -1
+	}
+	source.lock.Lock()
+	defer source.lock.Unlock()
+	if source.reader == nil {
 		return -1
 	}
 	sh := &reflect.SliceHeader{
@@ -43,12 +54,18 @@ func goSourceSeek(
 	ptr unsafe.Pointer, offset C.longlong, whence int,
 ) C.longlong {
 	source, ok := pointer.Restore(ptr).(*Source)
-	if ok && source.seeker != nil {
-		switch whence {
-		case io.SeekStart, io.SeekCurrent, io.SeekEnd:
-			if n, err := source.seeker.Seek(int64(offset), whence); err == nil {
-				return C.longlong(n)
-			}
+	if !ok {
+		return -1
+	}
+	source.lock.Lock()
+	defer source.lock.Unlock()
+	if source.seeker == nil {
+		return -1
+	}
+	switch whence {
+	case io.SeekStart, io.SeekCurrent, io.SeekEnd:
+		if n, err := source.seeker.Seek(int64(offset), whence); err == nil {
+			return C.longlong(n)
 		}
 	}
 	return -1
@@ -60,6 +77,11 @@ func goTargetWrite(
 ) C.longlong {
 	target, ok := pointer.Restore(ptr).(*Target)
 	if !ok {
+		return -1
+	}
+	target.lock.Lock()
+	defer target.lock.Unlock()
+	if target.writer == nil {
 		return -1
 	}
 	sh := &reflect.SliceHeader{
@@ -80,12 +102,18 @@ func goTargetSeek(
 	ptr unsafe.Pointer, offset C.longlong, whence int,
 ) C.longlong {
 	target, ok := pointer.Restore(ptr).(*Target)
-	if ok && target.seeker != nil {
-		switch whence {
-		case io.SeekStart, io.SeekCurrent, io.SeekEnd:
-			if n, err := target.seeker.Seek(int64(offset), whence); err == nil {
-				return C.longlong(n)
-			}
+	if !ok {
+		return -1
+	}
+	target.lock.Lock()
+	defer target.lock.Unlock()
+	if target.seeker == nil {
+		return -1
+	}
+	switch whence {
+	case io.SeekStart, io.SeekCurrent, io.SeekEnd:
+		if n, err := target.seeker.Seek(int64(offset), whence); err == nil {
+			return C.longlong(n)
 		}
 	}
 	return -1

--- a/vips817/connection.go
+++ b/vips817/connection.go
@@ -37,24 +37,30 @@ func NewSource(reader io.ReadCloser) *Source {
 }
 
 // Close source
+//
+// Holds s.lock through the entire teardown (including the s.reader = nil
+// write) so it cannot race with goSourceRead, which also takes s.lock
+// before reading s.reader. C.clear_source -> g_clear_object only fires
+// GLib dispose/finalize handlers, never the registered "read" signal,
+// so calling it under the Go lock cannot deadlock against an in-flight
+// goSourceRead callback.
 func (s *Source) Close() {
 	if s == nil {
 		return
 	}
 	s.lock.Lock()
-	if s.ptr != nil {
-		C.clear_source(&s.src)
-		pointer.Unref(s.ptr)
-		s.ptr = nil
-		s.lock.Unlock()
-		if s.reader != nil {
-			_ = s.reader.Close()
-			s.reader = nil
-		}
-		log("vipsgen", LogLevelDebug, fmt.Sprintf("closing source %p", s))
-	} else {
-		s.lock.Unlock()
+	defer s.lock.Unlock()
+	if s.ptr == nil {
+		return
 	}
+	C.clear_source(&s.src)
+	pointer.Unref(s.ptr)
+	s.ptr = nil
+	if s.reader != nil {
+		_ = s.reader.Close()
+		s.reader = nil
+	}
+	log("vipsgen", LogLevelDebug, fmt.Sprintf("closing source %p", s))
 }
 
 // Target contains a libvips VipsTargetCustom and manages its lifecycle.
@@ -82,22 +88,25 @@ func NewTarget(writer io.WriteCloser) *Target {
 }
 
 // Close target
+//
+// Symmetric fix to Source.Close: holds t.lock through t.writer = nil so
+// it cannot race with goTargetWrite, which also takes t.lock before
+// reading t.writer.
 func (t *Target) Close() {
 	if t == nil {
 		return
 	}
 	t.lock.Lock()
-	if t.ptr != nil {
-		C.clear_target(&t.target)
-		pointer.Unref(t.ptr)
-		t.ptr = nil
-		t.lock.Unlock()
-		if t.writer != nil {
-			_ = t.writer.Close()
-			t.writer = nil
-		}
-		log("vipsgen", LogLevelDebug, fmt.Sprintf("closing target %p", t))
-	} else {
-		t.lock.Unlock()
+	defer t.lock.Unlock()
+	if t.ptr == nil {
+		return
 	}
+	C.clear_target(&t.target)
+	pointer.Unref(t.ptr)
+	t.ptr = nil
+	if t.writer != nil {
+		_ = t.writer.Close()
+		t.writer = nil
+	}
+	log("vipsgen", LogLevelDebug, fmt.Sprintf("closing target %p", t))
 }

--- a/vips817/race_helpers.go
+++ b/vips817/race_helpers.go
@@ -1,0 +1,20 @@
+//go:build race
+
+// Helpers compiled only under -race. Kept in a non-_test.go file because
+// Go disallows cgo statements inside _test.go files when the package
+// already uses cgo (vips package builds with cgo via util.go etc.).
+
+package vips
+
+// #cgo pkg-config: vips
+// #include "util.h"
+import "C"
+
+// raceTestSetConcurrency sets libvips' worker thread count and returns the
+// previous value. Used by source_close_race_test.go to pin libvips to a
+// single worker thread for deterministic race-window reproduction.
+func raceTestSetConcurrency(n int) int {
+	prev := int(C.vips_concurrency_get())
+	C.vips_concurrency_set(C.int(n))
+	return prev
+}

--- a/vips817/source_close_bench_test.go
+++ b/vips817/source_close_bench_test.go
@@ -1,0 +1,102 @@
+package vips
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"testing"
+)
+
+// BenchmarkProcessJPEG_NoOps measures end-to-end cost of decoding a JPEG
+// through a custom Source and re-encoding through a custom Target — the
+// hot path for image-pipeline applications. Each iteration fires many
+// goSourceRead callbacks (decode) and goTargetWrite callbacks (encode),
+// so it captures the per-callback lock overhead introduced by the
+// Source/Target close-vs-callback race fix.
+func BenchmarkProcessJPEG_NoOps(b *testing.B) {
+	data := makeBenchJPEG(b, 800, 600)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := NewSource(io.NopCloser(bytes.NewReader(data)))
+		im, err := NewImageFromSource(src, nil)
+		if err != nil || im == nil {
+			b.Fatalf("NewImageFromSource: %v", err)
+		}
+		var out bytes.Buffer
+		tgt := NewTarget(benchNopWriteCloser{w: &out})
+		if err := im.JpegsaveTarget(tgt, nil); err != nil {
+			b.Fatalf("JpegsaveTarget: %v", err)
+		}
+		tgt.Close()
+		im.Close()
+		src.Close()
+	}
+}
+
+// BenchmarkProcessJPEG_Thumbnail measures shrink-on-load — the same path
+// as a typical thumbnail-generator service. Triggers many small reads via
+// the source callback during the shrink-on-load phase.
+func BenchmarkProcessJPEG_Thumbnail(b *testing.B) {
+	data := makeBenchJPEG(b, 1600, 1200)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := NewSource(io.NopCloser(bytes.NewReader(data)))
+		im, err := NewThumbnailSource(src, 200, &ThumbnailSourceOptions{
+			Height: 150,
+			Size:   SizeForce,
+		})
+		if err != nil || im == nil {
+			b.Fatalf("NewThumbnailSource: %v", err)
+		}
+		var out bytes.Buffer
+		tgt := NewTarget(benchNopWriteCloser{w: &out})
+		if err := im.JpegsaveTarget(tgt, nil); err != nil {
+			b.Fatalf("JpegsaveTarget: %v", err)
+		}
+		tgt.Close()
+		im.Close()
+		src.Close()
+	}
+}
+
+// BenchmarkSourceCloseSync isolates the Source.Close + NewSource cycle to
+// directly measure the cost of the per-callback sync.Mutex Lock/Unlock
+// added by the fix. No actual decode work — just the lifecycle overhead.
+func BenchmarkSourceCloseSync(b *testing.B) {
+	data := makeBenchJPEG(b, 100, 100)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := NewSource(io.NopCloser(bytes.NewReader(data)))
+		src.Close()
+	}
+}
+
+type benchNopWriteCloser struct{ w io.Writer }
+
+func (n benchNopWriteCloser) Write(p []byte) (int, error) { return n.w.Write(p) }
+func (n benchNopWriteCloser) Close() error                { return nil }
+
+func makeBenchJPEG(b *testing.B, w, h int) []byte {
+	b.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x * 7) % 256),
+				G: uint8((y * 13) % 256),
+				B: uint8(((x + y) * 3) % 256),
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80}); err != nil {
+		b.Fatalf("jpeg.Encode: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/vips817/source_close_race_test.go
+++ b/vips817/source_close_race_test.go
@@ -1,0 +1,165 @@
+//go:build race
+
+package vips
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"sync"
+	"testing"
+)
+
+// withSingleThreadedVips pins libvips to 1 worker thread for the duration of
+// the test, restoring the previous setting on exit. Single-threaded libvips
+// matches the moonglade fleet config where the race was first observed and
+// reliably surfaces it under -race; with auto-concurrency libvips finishes
+// callbacks fast enough that the race window almost always closes before
+// Source.Close runs in the calling goroutine. Implemented in
+// race_helpers.go so the cgo call is not in a _test.go file (Go disallows
+// cgo in test files when the surrounding package already uses cgo).
+func withSingleThreadedVips(t *testing.T) {
+	t.Helper()
+	prev := raceTestSetConcurrency(1)
+	t.Cleanup(func() { raceTestSetConcurrency(prev) })
+}
+
+// TestSource_CloseCallbackRace stresses (*Source).Close concurrent with the
+// goSourceRead callback fired by libvips while decoding through a custom
+// source. On the unpatched library the race detector reports:
+//
+//	WARNING: DATA RACE
+//	Write at 0x... by goroutine N:
+//	  vips.(*Source).Close()    connection.go:52   // s.reader = nil
+//	Previous read at 0x... by goroutine M:
+//	  vips.goSourceRead()       callback.go:32     // source.reader.Read
+//
+// Source.Close releases s.lock and then writes s.reader = nil outside the
+// lock; goSourceRead reads source.reader without holding any lock. After
+// libvips has released its synchronous reference, callback "extra"
+// goroutines (Go's cgo callback dispatchers) may still be unwinding when
+// Close runs — that is the race window.
+//
+// The trigger pattern is `Close source while a vips.Image keeps libvips'
+// reference alive`. shrink-on-load (NewThumbnailSource) reads enough bytes
+// to produce the thumbnail synchronously, but libvips may still hold the
+// source via the returned image until the image is destroyed; closing the
+// source first surfaces the race against the still-pending callback
+// goroutine. Build-tagged `race` so the load test is only compiled when
+// the race detector is the test verdict.
+func TestSource_CloseCallbackRace(t *testing.T) {
+	withSingleThreadedVips(t)
+	data := makeRaceTestJPEG(t, 800, 600)
+
+	workers := 16
+	const perWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range perWorker {
+				// Wrap the bytes reader in io.NopCloser so the Source falls
+				// through the non-seekable branch — same shape libvips ends up
+				// dispatching to a worker thread for.
+				src := NewSource(io.NopCloser(chainReader{r: bytes.NewReader(data)}))
+				// NewImageFromSource is lazy — the returned Image is an
+				// operation graph that pulls bytes from source on demand.
+				// JpegsaveTarget below forces the pull, firing goSourceRead
+				// callbacks on libvips worker goroutines. Closing the source
+				// while the image still holds the libvips reference is the
+				// race window.
+				im, err := NewImageFromSource(src, nil)
+				if err != nil || im == nil {
+					src.Close()
+					continue
+				}
+				var out bytes.Buffer
+				tgt := NewTarget(nopWriteCloser{w: &out})
+				// Close source first — image is still alive, libvips
+				// will still try to read through goSourceRead during
+				// JpegsaveTarget below.
+				src.Close()
+				_ = im.JpegsaveTarget(tgt, nil)
+				tgt.Close()
+				im.Close()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestTarget_CloseCallbackWriteRace mirrors the source test for Target.Close
+// vs goTargetWrite. Source is closed last so the source side of the
+// pipeline doesn't interfere; we close the Target while libvips may still
+// be flushing through goTargetWrite from JpegsaveTarget.
+func TestTarget_CloseCallbackWriteRace(t *testing.T) {
+	withSingleThreadedVips(t)
+	data := makeRaceTestJPEG(t, 800, 600)
+
+	workers := 16
+	const perWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range perWorker {
+				src := NewSource(io.NopCloser(chainReader{r: bytes.NewReader(data)}))
+				im, err := NewThumbnailSource(src, 100, nil)
+				if err != nil || im == nil {
+					src.Close()
+					continue
+				}
+				var out bytes.Buffer
+				tgt := NewTarget(nopWriteCloser{w: &out})
+				_ = im.JpegsaveTarget(tgt, nil)
+				// Close target BEFORE im.Close so libvips can still hold
+				// the target ref via the image during the unwind.
+				tgt.Close()
+				im.Close()
+				src.Close()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+type nopWriteCloser struct{ w io.Writer }
+
+func (n nopWriteCloser) Write(p []byte) (int, error) { return n.w.Write(p) }
+func (n nopWriteCloser) Close() error                { return nil }
+
+// chainReader wraps an io.Reader to mimic the wrapping-chain shape that
+// real-world callers produce (validating wrappers, decompression streams,
+// sniff buffers). The extra indirection slows Read just enough that the
+// cgo callback goroutine has not finished unwinding when Source.Close runs
+// in the calling goroutine — which is the race window. bytes.Reader.Read
+// is so fast the window almost never opens.
+type chainReader struct{ r io.Reader }
+
+func (c chainReader) Read(p []byte) (int, error) { return c.r.Read(p) }
+
+func makeRaceTestJPEG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x * 7) % 256),
+				G: uint8((y * 13) % 256),
+				B: uint8(((x + y) * 3) % 256),
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80}); err != nil {
+		t.Fatalf("jpeg.Encode: %v", err)
+	}
+	return buf.Bytes()
+}


### PR DESCRIPTION
## AI disclosure

This PR was written by an AI agent (Claude) and reviewed/curated by @SharkMagnus before submission. Please review accordingly.

## Symptom

`(*Source).Close` and `(*Target).Close` race against the `goSource*` / `goTarget*` callbacks. In production it surfaces as sporadic `VipsJpeg: premature end of JPEG image` errors when a caller closes a `Source` while a live `Image` still holds libvips' reference to it.

## Race report (under `go test -race`)

```
WARNING: DATA RACE
Write at 0x... by goroutine N:
  vips.(*Source).Close()    connection.go:52   // s.reader = nil
Previous read at 0x... by goroutine M:
  vips.goSourceRead()       callback.go:32     // source.reader.Read(buf)
```

`Close` releases `s.lock` and then writes `s.reader = nil` outside the lock; `goSourceRead` reads `source.reader` without holding the lock at all. Same shape for `Target.Close` vs `goTargetWrite` / `goTargetSeek`.

## Verified to be in the Go bindings, not libvips

- The raced location `s.reader` is a Go struct field (`io.ReadCloser` declared in `connection.go`). libvips can't read or write Go memory directly.
- Both stack frames in the race report are vipsgen Go code. No libvips C function appears in either stack.
- libvips invoking signal callbacks from worker threads is documented GLib/GObject behaviour; the contract is that the consumer (this binding) provides thread-safe handlers.
- The fix is entirely in Go (`connection.go` + `callback.go`); no C files (`connection.c`, `connection.h`) are touched.

## Reproduction

`vips/source_close_race_test.go` (build-tagged `race`) is the minimal repro. Core loop:

```go
for range 50 {
    src := NewSource(io.NopCloser(chainReader{r: bytes.NewReader(data)}))
    im, _ := NewImageFromSource(src, nil) // lazy — pulls bytes on save
    var out bytes.Buffer
    tgt := NewTarget(nopWriteCloser{w: &out})
    src.Close()                            // close while Image still alive
    _ = im.JpegsaveTarget(tgt, nil)        // forces goSourceRead
    tgt.Close(); im.Close()
}
```

16 goroutines run that loop in parallel. The test calls `vips_concurrency_set(1)` so the race window is deterministic across CI hosts (with auto-concurrency libvips finishes callbacks fast enough to almost always close the window before `Close` runs).

```
go test -race -run TestSource_CloseCallbackRace ./vips/
go test -race -run TestSource_CloseCallbackRace ./vips816/
go test -race -run TestSource_CloseCallbackRace ./vips817/
```

Pre-fix: `DATA RACE` on the first run.
Post-fix (this PR): clean across all three packages, repeated runs.

## Fix

- `Source.Close` / `Target.Close` hold `lock` through the entire teardown, including the `reader = nil` / `writer = nil` write.
- `goSourceRead` / `goSourceSeek` / `goTargetWrite` / `goTargetSeek` take the matching `lock` before touching `reader` / `writer` / `seeker`, returning `-1` when a concurrent `Close` has already nil'd the field.
- `C.clear_source` → `g_clear_object` only fires GLib dispose/finalize handlers, never the registered `read` / `write` / `seek` signals, so invoking it under the Go lock cannot deadlock against an in-flight callback.

Applied in `internal/templates/{connection,callback}.go.tmpl` and propagated to the three generated targets `vips/`, `vips816/`, `vips817/`.

## Test plan

- [x] `go test -race ./vips/ ./vips816/ ./vips817/` — all green pre-existing.
- [x] `go test -race -run TestSource_CloseCallbackRace ./vips/ ./vips816/ ./vips817/` — pre-fix fails (DATA RACE), post-fix passes ≥3× consecutive.
- [x] `go test ./...` — full suite green.